### PR TITLE
Add quotation marks around variable names in downloading code if needed

### DIFF
--- a/R/interactive_pxweb_internal.R
+++ b/R/interactive_pxweb_internal.R
@@ -75,7 +75,9 @@ download_pxweb <- function(dataNode, test_input = NULL, ...) {
     # Save the alternative to use to download data 
     varList[[listElem$code]] <- tempAlt    
     varListText <- c(varListText,
-                     str_c(listElem$code,
+                     str_c(ifelse(grepl(" ", listElem$code), 
+                                  str_c("\"", listElem$code, "\"", collapse=""), 
+                                  listElem$code),
                            " = c('",
                            str_c(tempAlt, collapse="', '"),
                            "')", 

--- a/tests/testthat/test-get_pxweb_data.R
+++ b/tests/testthat/test-get_pxweb_data.R
@@ -94,10 +94,10 @@ test_that(desc="get_pxweb_data()",{
     
     list(
       url = "http://pxnet2.stat.fi/PXWeb/api/v1/fi/StatFin/asu/asas/010_asas_tau_101.px",
-      dims = list("Alue" = c("*"),
+      dims = list(Alue = c("*"),
                   "Asuntokunnan koko" = c("*"),
-                  "Talotyyppi" = c("S"),
-                  "Vuosi" = c("*")
+                  Talotyyppi = c("S"),
+                  Vuosi = c("*")
       ),
       clean = TRUE,
       test_dim = c(2568, NA)


### PR DESCRIPTION
When printing a code for downloading there should be quotation marks around variable names, if the name includes space(s).
Closes #74 (the remaining issue).

A test in test-get_pxweb_data for statfi is updated to a same format (probably does not make a difference).