### PR TITLE
New api: statdb.luke.fi.

### DIFF
--- a/inst/extdata/api.json
+++ b/inst/extdata/api.json
@@ -16,7 +16,7 @@
         "description" : "Statistics Finland",
         "url" : "http://pxnet2.stat.fi/PXWeb/api/[version]/[lang]",
         "version": ["v1"], 
-        "lang": ["fi"],
+        "lang": ["fi", "sv", "en"],
         "calls_per_period": 30,
         "period_in_seconds": 10,
         "max_values_to_download" : 100000
@@ -73,6 +73,17 @@
         "calls_per_period": 30,
         "period_in_seconds": 1,
         "max_values_to_download" : 10000
+              },
+    
+    "statdb.luke.fi": {
+        "alias" : ["luke"],
+        "description" : "LUKE Natural Resources Institute Finland",
+        "url" : "http://statdb.luke.fi/PXWeb/api/[version]/[lang]",
+        "version": ["v1"], 
+        "lang": ["fi", "sv", "en"],
+        "calls_per_period": 30,
+        "period_in_seconds": 10,
+        "max_values_to_download" : 100000
               }
 
   },


### PR DESCRIPTION
Add an api for new pxweb database of LUKE, Natural Resources Institute Finland: stat.luke.fi

Add also languages sv and en to the statfi-api.