### PR TITLE
Suggested bug fix

### DIFF
--- a/R/utils_internal.R
+++ b/R/utils_internal.R
@@ -129,11 +129,20 @@ create_batch_list <- function(url, dims){
     no_batch <- dim_length[arg_max] %/% batch_size
     if(dim_length[arg_max] %% batch_size != 0) no_batch <- no_batch + 1
     message("This is a large query. The data will be downloaded in ",no_batch," batches.")
+
+    # Find which levels we want to use
+    all_levels_arg_max <- node$variables$variables[[arg_max]]$values
+    levels_arg_max <-
+      if (length(dims[[arg_max]] == 1) && dims[[arg_max]] == "*") {
+        all_levels_arg_max
+      } else {
+        all_levels_arg_max[all_levels_arg_max %in% dims[[arg_max]]]
+      }
+
     # Create list with calls
     batch_list <- list(url=url, dims=list(), content_node=node)
     for (b in 1:no_batch){ # b <- 1
-      batch_values_index <- ((b-1)*batch_size+1):min((b*batch_size), dim_length[arg_max])
-      batch_values <- node$variables$variables[[arg_max]]$values[batch_values_index]
+      batch_values <- levels_arg_max[((b-1)*batch_size+1):min((b*batch_size), dim_length[arg_max])]
       batch_list$dims[[b]] <- dims
       batch_list$dims[[b]][[names(dim_length[arg_max])]] <- batch_values
     }

--- a/tests/testthat/test-get_pxweb_data.R
+++ b/tests/testthat/test-get_pxweb_data.R
@@ -120,10 +120,13 @@ test_that(desc="get_pxweb_data()",{
     
     list( 
       url = "http://api.scb.se/OV0104/v1/doris/en/ssd/BE/BE0401/BE0401A/BefolkprognRev2014",
+      url = "http://api.scb.se/OV0104/v1/doris/en/ssd/BE/BE0401/BE0401A/BefolkprognRev2015",
       dims = list(Alder = c('0', '1', '2', '3', '4'),
                   Kon = c('1', '2'),
                   ContentsCode = c('BE0401AW'),
                   Tid = c('2014', '2015', '2016', '2017', '2018')),
+                  ContentsCode = c('0000008J'),
+                  Tid = c('2015', '2016', '2017', '2018', '2019')),
       clean = FALSE,
       test_dim = c(NA, NA))  
     

--- a/tests/testthat/test-get_pxweb_data.R
+++ b/tests/testthat/test-get_pxweb_data.R
@@ -117,14 +117,11 @@ test_that(desc="get_pxweb_data()",{
       ),
       clean = TRUE
     ),
-    
-    list( 
-      url = "http://api.scb.se/OV0104/v1/doris/en/ssd/BE/BE0401/BE0401A/BefolkprognRev2014",
+
+    list(
       url = "http://api.scb.se/OV0104/v1/doris/en/ssd/BE/BE0401/BE0401A/BefolkprognRev2015",
       dims = list(Alder = c('0', '1', '2', '3', '4'),
                   Kon = c('1', '2'),
-                  ContentsCode = c('BE0401AW'),
-                  Tid = c('2014', '2015', '2016', '2017', '2018')),
                   ContentsCode = c('0000008J'),
                   Tid = c('2015', '2016', '2017', '2018', '2019')),
       clean = FALSE,

--- a/tests/testthat/test-get_pxweb_metadata.R
+++ b/tests/testthat/test-get_pxweb_metadata.R
@@ -37,7 +37,7 @@ test_that(desc="baseURL 2",{
     "http://api.scb.se/OV0104/v1/doris/sv/ssd/HA/HA0201/HA0201B/ExpTotalKNMan",
     "http://api.scb.se/OV0104/v1/doris/sv/ssd/HA/HA0201/HA0201B/ExpTotalKNAr",
     "http://api.scb.se/OV0104/v1/doris/sv/ssd/HA/HA0201/HA0201B/ImpTotalKNMan",
-    "http://api.scb.se/OV0104/v1/doris/en/ssd/BE/BE0401/BE0401A/BefolkprognRev2014",
+    "http://api.scb.se/OV0104/v1/doris/en/ssd/BE/BE0401/BE0401A/BefolkprognRev2015",
     "http://api.scb.se/OV0104/v1/doris/en/ssd/UF/UF0536/Fullfoljt"
   )
 


### PR DESCRIPTION
When I was working with the same data as in #94 I had 83 different ages I wanted to download. 
When I executed the query I did actually get data for 83 distinct age levels but not the ones I expected. 

A toy example; let´s say I wanted:
```{r}
dims <- list(
   ...,
   Alder = c(1, 2, 5, 6),
   ...
)
```

... pretend that this query is too big for one batch and therefore has to be split. The split is made based on "Alder" into 2 batches made of ``` c(1, 2, )```and ```c(5, 6)```.
But here was an index issue that somehow releveled to: ``` c(1, 2, )```and ```c(3, 4)```. Hence, all levels had to be in consecutive order for this translation to work.

This pull request seems to fix that!
And in the process I had to update two tests since the data structure at SCB seems to have changed a little since last year. 

