### PR TITLE
add API Statistics Norway SSB

### DIFF
--- a/inst/extdata/api.json
+++ b/inst/extdata/api.json
@@ -172,7 +172,18 @@
         "calls_per_period": 30,
         "period_in_seconds": 10,
         "max_values_to_download" : 100000
-     }
+    },
+
+    "data.ssb.no": { 
+        "alias" : ["ssb"],
+        "description" : "Statistics Norway",
+        "url" : "http://data.ssb.no/api/[version]/[lang]",
+        "version": ["v0"], 
+        "lang": ["en"],
+        "calls_per_period": 30,
+        "period_in_seconds": 10,
+        "max_values_to_download" : 100000
+    }
 
   },
 

--- a/vignettes/pxweb.Rmd
+++ b/vignettes/pxweb.Rmd
@@ -86,6 +86,9 @@ d <- interactive_pxweb(api = "api.scb.se", version = "v1", lang = "sv")
 
 # Fetching data from statfi (Statistics Finland)
 d <- interactive_pxweb(api = "pxwebapi2.stat.fi")
+
+# Fetching data from StatBank (Statistics Norway)
+d <- interactive_pxweb(api = "data.ssb.no")
 ```
 
 Example of download data from the Statistics Sweden API using `get_pxweb_data()`:
@@ -95,6 +98,19 @@ pxweb_test_data <-
   get_pxweb_data(url = "http://api.scb.se/OV0104/v1/doris/sv/ssd/PR/PR0101/PR0101E/Basbeloppet", 
                  dims = list(ContentsCode = c('PR0101A1'), 
                              Tid = c('*')),
+                 clean = FALSE)
+```
+
+Example of download data from the Statistics Norway API using `get_pxweb_data()`:
+
+```{r directquery-ssb, message=FALSE, eval=FALSE}
+pxweb_test_data_ssb <- 
+  get_pxweb_data(url = "http://data.ssb.no/api/v0/en/table/vf/vf01/aksjer/ASKapital",
+                 dims = list(
+                   NACE2007 = c('A_U'),
+                   ContentsCode = c('ASer'),
+                   Tid = c('*')
+                 ),
                  clean = FALSE)
 ```
 


### PR DESCRIPTION
The [preliminary StatBank API user guide](http://www.ssb.no/en/omssb/tjenester-og-verktoy/api/px-api/_attachment/248250?_ts=1559219c7b8) published by Statistics Norway mentions: *We basically use the same API code as Statics Sweden (SCB), plus our own developed console. See
http://www.scb.se/api_en/. See also their API guide: http://www.scb.se/Grupp/OmSCB/API/API-
description.pdf*