### PR TITLE
Statistics Moldova added to api catalogue

### DIFF
--- a/inst/extdata/api.json
+++ b/inst/extdata/api.json
@@ -227,7 +227,19 @@
       "calls_per_period": 10,
       "period_in_seconds": 10,
       "max_values_to_download" : 1000
+    },
+    
+    "statbank.statistica.md": {
+      "alias" : ["statistica_md"],
+      "description" : "Statistics Moldova",
+      "url" : "http://statbank.statistica.md/pxweb/api/[version]/[lang]/",
+      "version": ["v1"], 
+      "lang": ["en", "ro"],
+      "calls_per_period": 10,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 1000
     }
+
  
   },
 


### PR DESCRIPTION
Statistics Moldova "statistical databank" http://statbank.statistica.md/pxweb/pxweb/ added to API catalogue.

