### PR TITLE
New PXWEB API for Latvia 

### DIFF
--- a/R/pxweb_query.R
+++ b/R/pxweb_query.R
@@ -197,7 +197,8 @@ pxweb_validate_query_with_metadata <- function(pxq, pxmd){
     }
   }
   if(!all(mandatory_variables %in% query_variables)){
-    stop("Not all mandatory variables are included in the query.", call. = FALSE)
+    mandatory_variables_missing <- mandatory_variables[!mandatory_variables %in% query_variables]
+    stop("Mandatory variable(s) '", paste0(mandatory_variables_missing, collapse = "', '"), "' is missing in the query.", call. = FALSE)
   }
 }
 

--- a/tests/testthat/test-pxweb_get.R
+++ b/tests/testthat/test-pxweb_get.R
@@ -242,3 +242,17 @@ test_that(desc="manually supplying a pxmdo",{
   expect_identical(px_data1$data, px_data2$data)
   
 })  
+
+
+test_that(desc="return clear error message when missing values",{
+  # CRAN seem to run tests in parallel, hence API tests cannot be run on CRAN.
+  skip_on_cran()
+
+  pql <- list("Tilltalsnamn"=c("20Agnes"),
+              "Tid"=c("2019"))
+  url <- "http://api.scb.se/OV0104/v1/doris/sv/ssd/START/BE/BE0001/BE0001D/BE0001T05AR"
+  expect_error(pd <- pxweb_get(url, query = pql), regexp = "ContentsCode")
+  
+})  
+
+


### PR DESCRIPTION
Can you please make a new PXWEB API for Latvia in the global catalogue with  “data.stat.gov.lv” (saving the old one "data.csb.gov.lv")? The description for the new one is “Latvia – official statistics” and  URL : “http://data.stat.gov.lv/api/[version]/[lang]/” .
