### PR TITLE
Fix issue #245, include topic to reference index

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -13,6 +13,7 @@ reference:
   - pxweb_validate_query_with_metadata
   - api_catalogue
   - assert_query_can_be_split_to_batches
+  - pxweb_query_as_rcode
 - title: Interactive functions
   desc: |
     Listing of interactive functions


### PR DESCRIPTION
Should fix the following error in building a pkgdown webpage from a template:

```
-- Building function reference -------------------------------------------------
Error in `check_missing_topics()`:
! All topics must be included in reference index
• Missing topics: pxweb_query_as_rcode
```