### PR TITLE
Fix missing pages on gh deployment

### DIFF
--- a/.github/workflows/rogtemplate-gh-pages.yaml
+++ b/.github/workflows/rogtemplate-gh-pages.yaml
@@ -30,6 +30,8 @@ jobs:
             any::pkgdown
             ropengov/rogtemplate
             any::magick
+            any::devtools
+            any::remotes
 
       - name: Build logo if not present and prepare template
         run: |


### PR DESCRIPTION
Fix #245 

Issue was that some additional packages (`devtools`?) was added on the article. While this is not a problem when checking the package (articles are ignored, vignettes are not), but when running `pkgdown` all needed packages needs to be installed.

Packages needed on vignettes are declared on DESCRIPTION, while articles can have additional packages (I often do this), but then it is neccesary to ensure that the GH action also installs the packages needed on the articles.

Hope this make sense, regards 