### PR TITLE
Add new APIs to catalogue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: pxweb
 Title: R Interface to PXWEB APIs
-Version: 0.16.2
-Date: 2022-10-31
+Version: 0.16.3
+Date: 2023-05-29
 Authors@R: c(
     person("Mans", "Magnusson", , "mons.magnusson@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0296-2719")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,8 +28,7 @@ Description: Generic interface for the PX-Web/PC-Axis API. The
     files in dynamic tables on the web.  Since 2013 PX-Web contains an API
     to disseminate PC-Axis files.
 License: BSD_2_clause + file LICENSE
-URL: https://github.com/rOpenGov/pxweb/,
-    https://ropengov.github.io/pxweb/, https://github.com/rOpenGov/pxweb
+URL: https://github.com/rOpenGov/pxweb/, https://ropengov.github.io/pxweb/ 
 BugReports: https://github.com/rOpenGov/pxweb/issues
 Depends:
     R (>= 3.5.0)
@@ -47,6 +46,6 @@ Suggests:
 VignetteBuilder: 
     knitr
 Encoding: UTF-8
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.3
 X-schema.org-isPartOf: http://ropengov.org/
 X-schema.org-keywords: ropengov

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,24 +1,25 @@
-citHeader("Kindly cite the pxweb R package as follows:")
+citHeader("To cite pxweb in publications use:")
 
 year <- sub(".*(2[[:digit:]]{3})-.*", "\\1", meta$Date, perl = TRUE)
 vers <- paste("R package version", meta$Version)
 
-citEntry(entry="misc",
-         title = "pxweb: R tools for PX-WEB API",
-         author = personList(
-	   person(given = "Mans", family= "Magnusson", email = "mons.magnusson@gmail.com"),
-	   person(given = "Markus", family= "Kainu"),
-	   person(given = "Janne", family= "Huovari"),
-	   person(given = "Leo", family= "Lahti")
-         ),
-	 year = year,
-	 note = vers,
-         textVersion =
-         paste("Mans Magnusson, Markus Kainu, Janne Huovari, and Leo Lahti (",year,"). ",
+bibentry(
+  bibtype  = "misc",
+  key      = "pxweb",
+  title    = "pxweb: R tools for PX-WEB API",
+  author   = c(
+    person(given = "Mans", family= "Magnusson", email = "mons.magnusson@gmail.com"),
+    person(given = "Markus", family= "Kainu"),
+    person(given = "Janne", family= "Huovari"),
+    person(given = "Leo", family= "Lahti")
+  ),
+  year     = year,
+  note     = vers,
+  url      = "https://github.com/rOpenGov/pxweb",
+  textVersion = paste("Mans Magnusson, Markus Kainu, Janne Huovari, and Leo Lahti (",year,"). ",
                "pxweb: R tools for PXWEB API. ",
                vers,
-	       " URL: http://github.com/ropengov/pxweb",
-               sep="")
-         )
-
-
+	             " URL: https://github.com/rOpenGov/pxweb",
+               sep=""
+  )
+)

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,5 +1,8 @@
 citHeader("Kindly cite the pxweb R package as follows:")
 
+year <- sub(".*(2[[:digit:]]{3})-.*", "\\1", meta$Date, perl = TRUE)
+vers <- paste("R package version", meta$Version)
+
 citEntry(entry="misc",
          title = "pxweb: R tools for PX-WEB API",
          author = personList(
@@ -8,13 +11,14 @@ citEntry(entry="misc",
 	   person(given = "Janne", family= "Huovari"),
 	   person(given = "Leo", family= "Lahti")
          ),
-	 journal = "",
-	 year = "2019",
+	 year = year,
+	 note = vers,
          textVersion =
-         paste("Mans Magnusson, Markus Kainu, Janne Huovari, and Leo Lahti (rOpenGov). ",
+         paste("Mans Magnusson, Markus Kainu, Janne Huovari, and Leo Lahti (",year,"). ",
                "pxweb: R tools for PXWEB API. ",
-	       "URL: http://github.com/ropengov/pxweb",
-               sep=" ")
+               vers,
+	       " URL: http://github.com/ropengov/pxweb",
+               sep="")
          )
 
 

--- a/inst/extdata/api.json
+++ b/inst/extdata/api.json
@@ -182,20 +182,6 @@
         "max_values_to_download" : 1000000
               },
 
-    "px.rsv.is": {
-        "alias" : ["rsv"],
-        "description" : "Icelandic Centre for Retail Studies",
-        "citation" : {
-          "organization" : "Icelandic Centre for Retail Studies",
-          "address" : "Reykjavík, Iceland"},
-        "url" : "http://px.rsv.is/PXWeb/api/[version]/[lang]",
-        "version": ["v1"], 
-        "lang": ["en", "is"],
-        "calls_per_period": 30,
-        "period_in_seconds": 1,
-        "max_values_to_download" : 10000
-              },
-
     "statbank.hagstova.fo": {
         "alias" : ["hagstovan"],
         "description" : "Statistics Faroe Islands",

--- a/inst/extdata/api.json
+++ b/inst/extdata/api.json
@@ -415,7 +415,232 @@
         "calls_per_period": 100,
         "period_in_seconds": 10,
         "max_values_to_download" : 10000000
+    },
+    
+  "web.dzs.hr": {
+      "description" : "Croatian Bureau of Statistics",
+      "citation" : {
+        "organization" : "Croatian Bureau of Statistics",
+        "address" : "Zagreb, Croatia"
+      },
+      "url" : "https://web.dzs.hr/PXWeb/api/[version]/[lang]/",
+      "version": ["v1"],
+      "lang": ["en", "hr"],
+      "calls_per_period": 100,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 10000000
+      },
+      
+    "www.eustat.eus": {
+      "description" : "Euskal Estatistika Erakundea",
+      "citation" : {
+        "organization" : "Eustat - Euskal Estatistika Erakundea - Instituto Vasco de Estadística",
+        "address" : "Donostia / San Sebastian, Spain"
+      },
+      "url" : "https://www.eustat.eus/bankupx/api/[version]/[lang]/DB",
+      "version": ["v1"],
+      "lang": ["en", "eu", "es"],
+      "calls_per_period": 100,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 10000000
+      },
+      
+    "pxweb.karlstad.se": {
+      "description" : "Karlstads kommuns statistikdatabas",
+      "citation" : {
+        "organization" : "Karlstads kommuns statistikdatabas",
+        "address" : "Karlstad, Sweden"
+      },
+      "url" : "http://pxweb.karlstad.se/api/[version]/[lang]/Karlstads_kommun/",
+      "version": ["v1"],
+      "lang": ["sv", "en"],
+      "calls_per_period": 100,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 10000000
+      },
+      
+    "pxweb.instat-mali.com": {
+      "description" : "INSTAT Mali",
+      "citation" : {
+        "organization" : "Institut National de la Statistique du Mali - INSTAT",
+        "address" : "Bamako, Mali"
+      },
+      "url" : "https://pxweb.instat-mali.com/PXWeb/api/[version]/[lang]/BaseDeDonnees/",
+      "version": ["v1"],
+      "lang": ["fr", "bm"],
+      "calls_per_period": 100,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 10000000
+      },
+      
+    "statistik.csn.se": {
+      "description" : "CSN: Officiell statistik inom området studiestöd",
+      "citation" : {
+        "organization" : "Centrala studiestödsnämnden (CSN)",
+        "address" : "Stockholm, Sweden"
+      },
+      "url" : "https://statistik.csn.se:443/PXWeb/api/[version]/[lang]/",
+      "version": ["v1"],
+      "lang": ["sv"],
+      "calls_per_period": 100,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 10000000
+      },
+      
+    "pxexternal.energimyndigheten.se": {
+      "description" : "Energimyndigheten statistikdatabas",
+      "citation" : {
+        "organization" : "Energimyndigheten - The Swedish Energy Agency",
+        "address" : "Eskilstuna, Sweden"
+      },
+      "url" : "http://pxexternal.energimyndigheten.se/api/[version]/[lang]/",
+      "version": ["v1"],
+      "lang": ["sv"],
+      "calls_per_period": 100,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 10000000
+      },
+      
+    "m02-http-pxwebb.login.sundsvall.se": {
+      "description" : "Sundsvalls kommuns statistikdatabas",
+      "citation" : {
+        "organization" : "Sundsvalls kommun",
+        "address" : "Sundsvall, Sweden"
+      },
+      "url" : "https://m02-http-pxwebb.login.sundsvall.se/PXWeb_Ext/api/[version]/[lang]/",
+      "version": ["v1"],
+      "lang": ["sv"],
+      "calls_per_period": 100,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 10000000
+      },
+      
+    "statistik.vasteras.se": {
+      "description" : "Västerås stads statistikdatabas",
+      "citation" : {
+        "organization" : "Västerås stad",
+        "address" : "Västerås, Sweden"
+      },
+      "url" : "https://statistik.vasteras.se:443/api/[version]/[lang]/",
+      "version": ["v1"],
+      "lang": ["sv"],
+      "calls_per_period": 100,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 10000000
+      },
+      
+    "px.web.ined.fr": {
+      "description" : "The Generations & Gender Contextual Database",
+      "citation" : {
+        "organization" : "Netherlands Interdisciplinary Demographic Institute",
+        "address" : "Den Haag, Netherlands"
+      },
+      "url" : "https://px.web.ined.fr:443/GGP/api/[version]/[lang]/",
+      "version": ["v1"],
+      "lang": ["en"],
+      "calls_per_period": 100,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 10000000
+      },
+      
+    "openstat.psa.gov.ph": {
+      "description" : "Philippine Statistics Authority OpenSTAT",
+      "citation" : {
+        "organization" : "Philippine Statistics Authority OpenSTAT",
+        "address" : "Quezon City, Philippines"
+      },
+      "url" : "https://openstat.psa.gov.ph:443/PXWeb/api/[version]/[lang]/",
+      "version": ["v1"],
+      "lang": ["en"],
+      "calls_per_period": 100,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 10000000
+    },
+    
+  "statistika.spkc.gov.lv": {
+      "description" : "Latvian Health Care Statistics Reports Database",
+      "citation" : {
+        "organization" : "Centre for Disease Prevention and Control of Latvia",
+        "address" : "Riga, Latvia"
+      },
+      "url" : "https://statistika.spkc.gov.lv:443/api/[version]/[lang]/",
+      "version": ["v1"],
+      "lang": ["en", "lv"],
+      "calls_per_period": 100,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 10000000
+    },
+    
+  "pxweb.irena.org": {
+      "description" : "IRENA Renewable Energy Statistics database",
+      "citation" : {
+        "organization" : "IRENA - International Renewable Energy Agency",
+        "address" : "Abu Dhabi, United Arab Emirates"
+      },
+      "url" : "https://pxweb.irena.org:443/api/[version]/[lang]/",
+      "version": ["v1"],
+      "lang": ["en", "fr", "es"],
+      "calls_per_period": 100,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 10000000
+    },
+    
+  "tilastot.etk.fi": {
+      "description" : "Finnish Centre for Pensions",
+      "citation" : {
+        "organization" : "ETK - Finnish Centre for Pensions",
+        "address" : "Helsinki, Finland"
+      },
+      "url" : "https://tilastot.etk.fi:443/api/[version]/[lang]/",
+      "version": ["v1"],
+      "lang": ["en", "fi", "sv"],
+      "calls_per_period": 100,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 10000000
+    },
+    
+  "41.94.86.11": {
+      "description" : "Instituto Nacional de Estatistica, Moçambique",
+      "citation" : {
+        "organization" : "Instituto Nacional de Estatistica",
+        "address" : "Maputo, Moçambique"
+      },
+      "url" : "http://41.94.86.11/Censo2017/api/[version]/[lang]/",
+      "version": ["v1"],
+      "lang": ["en", "pt-PT"],
+      "calls_per_period": 100,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 10000000
+    },
+    
+  "pc-axis.geostat.ge": {
+      "description" : "National Statistics Office of Georgia (Geostat)",
+      "citation" : {
+        "organization" : "National Statistics Office of Georgia (Geostat)",
+        "address" : "Tbilisi, Georgia"
+      },
+      "url" : "http://pc-axis.geostat.ge/PXweb/api/[version]/[lang]/",
+      "version": ["v1"],
+      "lang": ["en", "ka"],
+      "calls_per_period": 100,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 10000000
+    },
+    
+  "statistika.tai.ee": {
+      "description" : "Estonian Health Statistics and Health Research Database",
+      "citation" : {
+        "organization" : "National Institute for Health Development - Tervise Arengu Instituut",
+        "address" : "Tallinn, Estonia"
+      },
+      "url" : "https://statistika.tai.ee/api/[version]/[lang]/",
+      "version": ["v1"],
+      "lang": ["en", "et"],
+      "calls_per_period": 100,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 10000000
     }
+    
   },
   "local_apis": {}
 

--- a/inst/extdata/api.json
+++ b/inst/extdata/api.json
@@ -24,7 +24,7 @@
         "url" : "https://statfin.stat.fi/PXWeb/api/[version]/[lang]",
         "version": ["v1"], 
         "lang": ["en","fi","sv"],
-        "calls_per_period": 30,
+        "calls_per_period": 3000,
         "period_in_seconds": 10,
         "max_values_to_download" : 120000
               },
@@ -37,9 +37,9 @@
         "url" : "https://pxwebapi2.stat.fi/PXWeb/api/[version]/[lang]",
         "version": ["v1"], 
         "lang": ["fi"],
-        "calls_per_period": 1000,
+        "calls_per_period": 10,
         "period_in_seconds": 10,
-        "max_values_to_download" : 110000
+        "max_values_to_download" : 1000
               },
       
     "statistik.sjv.se": {
@@ -135,9 +135,9 @@
         "url" : "http://px.hagstofa.is/px[lang]/api/[version]/[lang]",
         "version": ["v1"], 
         "lang": ["en","is"],
-        "calls_per_period": 30,
-        "period_in_seconds": 1,
-        "max_values_to_download" : 10000
+        "calls_per_period": 10,
+        "period_in_seconds": 10,
+        "max_values_to_download" : 5000
               },
               
     "statistik.linkoping.se": {
@@ -247,9 +247,9 @@
       "url" : "https://makstat.stat.gov.mk/PXWeb/api/[version]/[lang]/MakStat/",
       "version": ["v1"], 
       "lang": ["en", "mk"],
-      "calls_per_period": 30,
-      "period_in_seconds": 1,
-      "max_values_to_download" : 10000
+      "calls_per_period": 10,
+      "period_in_seconds": 10,
+      "max_values_to_download" : 1000
     },
     
     "data.stat.gov.lv": {
@@ -300,9 +300,9 @@
       "citation" : {
           "organization" : "Kosovo Agency of Statistics",
           "address" : "Pristina, Kosovo"},
-      "url" : "https://askdata.rks-gov.net/PXWeb/api/[version]/[lang]/",
+      "url" : "https://askdata.rks-gov.net/api/[version]/[lang]/",
       "version": ["v1"], 
-      "lang": ["en"],
+      "lang": ["en", "sq"],
       "calls_per_period": 10,
       "period_in_seconds": 10,
       "max_values_to_download" : 1000
@@ -400,7 +400,7 @@
         "lang": ["en"],
         "calls_per_period": 100,
         "period_in_seconds": 10,
-        "max_values_to_download" : 1000
+        "max_values_to_download" : 1000000
     },
 
     "pxweb.stat.si": {

--- a/inst/extdata/api.json
+++ b/inst/extdata/api.json
@@ -385,9 +385,9 @@
         "url" : "https://andmed.stat.ee/api/[version]/[lang]/stat",
         "version": ["v1"], 
         "lang": ["en", "et"],
-        "calls_per_period": 1000,
+        "calls_per_period": 100,
         "period_in_seconds": 10,
-        "max_values_to_download" : 1000000
+        "max_values_to_download" : 25000000
     },
     
     "pxweb.nordicstatistics.org": {
@@ -398,7 +398,7 @@
         "url" : "https://pxweb.nordicstatistics.org/api/[version]/[lang]/",
         "version": ["v1"], 
         "lang": ["en"],
-        "calls_per_period": 10,
+        "calls_per_period": 100,
         "period_in_seconds": 10,
         "max_values_to_download" : 1000
     },
@@ -426,9 +426,9 @@
       "url" : "https://web.dzs.hr/PXWeb/api/[version]/[lang]/",
       "version": ["v1"],
       "lang": ["en", "hr"],
-      "calls_per_period": 100,
-      "period_in_seconds": 10,
-      "max_values_to_download" : 10000000
+      "calls_per_period": 30,
+      "period_in_seconds": 1,
+      "max_values_to_download" : 10000
       },
       
     "www.eustat.eus": {
@@ -440,9 +440,9 @@
       "url" : "https://www.eustat.eus/bankupx/api/[version]/[lang]/DB",
       "version": ["v1"],
       "lang": ["en", "eu", "es"],
-      "calls_per_period": 100,
-      "period_in_seconds": 10,
-      "max_values_to_download" : 10000000
+      "calls_per_period": 400,
+      "period_in_seconds": 400,
+      "max_values_to_download" : 1000
       },
       
     "pxweb.karlstad.se": {
@@ -454,9 +454,9 @@
       "url" : "http://pxweb.karlstad.se/api/[version]/[lang]/Karlstads_kommun/",
       "version": ["v1"],
       "lang": ["sv", "en"],
-      "calls_per_period": 100,
+      "calls_per_period": 10,
       "period_in_seconds": 10,
-      "max_values_to_download" : 10000000
+      "max_values_to_download" : 1000
       },
       
     "pxweb.instat-mali.com": {
@@ -468,9 +468,9 @@
       "url" : "https://pxweb.instat-mali.com/PXWeb/api/[version]/[lang]/BaseDeDonnees/",
       "version": ["v1"],
       "lang": ["fr", "bm"],
-      "calls_per_period": 100,
+      "calls_per_period": 10,
       "period_in_seconds": 10,
-      "max_values_to_download" : 10000000
+      "max_values_to_download" : 1000
       },
       
     "statistik.csn.se": {
@@ -482,9 +482,9 @@
       "url" : "https://statistik.csn.se:443/PXWeb/api/[version]/[lang]/",
       "version": ["v1"],
       "lang": ["sv"],
-      "calls_per_period": 100,
+      "calls_per_period": 10,
       "period_in_seconds": 10,
-      "max_values_to_download" : 10000000
+      "max_values_to_download" : 1000
       },
       
     "pxexternal.energimyndigheten.se": {
@@ -496,9 +496,9 @@
       "url" : "http://pxexternal.energimyndigheten.se/api/[version]/[lang]/",
       "version": ["v1"],
       "lang": ["sv"],
-      "calls_per_period": 100,
+      "calls_per_period": 10,
       "period_in_seconds": 10,
-      "max_values_to_download" : 10000000
+      "max_values_to_download" : 1000
       },
       
     "m02-http-pxwebb.login.sundsvall.se": {
@@ -510,9 +510,9 @@
       "url" : "https://m02-http-pxwebb.login.sundsvall.se/PXWeb_Ext/api/[version]/[lang]/",
       "version": ["v1"],
       "lang": ["sv"],
-      "calls_per_period": 100,
+      "calls_per_period": 10,
       "period_in_seconds": 10,
-      "max_values_to_download" : 10000000
+      "max_values_to_download" : 1000
       },
       
     "statistik.vasteras.se": {
@@ -524,9 +524,9 @@
       "url" : "https://statistik.vasteras.se:443/api/[version]/[lang]/",
       "version": ["v1"],
       "lang": ["sv"],
-      "calls_per_period": 100,
-      "period_in_seconds": 10,
-      "max_values_to_download" : 10000000
+      "calls_per_period": 30,
+      "period_in_seconds": 1,
+      "max_values_to_download" : 10000
       },
       
     "px.web.ined.fr": {
@@ -538,9 +538,9 @@
       "url" : "https://px.web.ined.fr:443/GGP/api/[version]/[lang]/",
       "version": ["v1"],
       "lang": ["en"],
-      "calls_per_period": 100,
+      "calls_per_period": 10,
       "period_in_seconds": 10,
-      "max_values_to_download" : 10000000
+      "max_values_to_download" : 1000
       },
       
     "openstat.psa.gov.ph": {
@@ -552,9 +552,9 @@
       "url" : "https://openstat.psa.gov.ph:443/PXWeb/api/[version]/[lang]/",
       "version": ["v1"],
       "lang": ["en"],
-      "calls_per_period": 100,
+      "calls_per_period": 10,
       "period_in_seconds": 10,
-      "max_values_to_download" : 10000000
+      "max_values_to_download" : 1000
     },
     
   "statistika.spkc.gov.lv": {
@@ -566,9 +566,9 @@
       "url" : "https://statistika.spkc.gov.lv:443/api/[version]/[lang]/",
       "version": ["v1"],
       "lang": ["en", "lv"],
-      "calls_per_period": 100,
+      "calls_per_period": 10,
       "period_in_seconds": 10,
-      "max_values_to_download" : 10000000
+      "max_values_to_download" : 1000
     },
     
   "pxweb.irena.org": {
@@ -580,9 +580,9 @@
       "url" : "https://pxweb.irena.org:443/api/[version]/[lang]/",
       "version": ["v1"],
       "lang": ["en", "fr", "es"],
-      "calls_per_period": 100,
+      "calls_per_period": 10,
       "period_in_seconds": 10,
-      "max_values_to_download" : 10000000
+      "max_values_to_download" : 1000
     },
     
   "tilastot.etk.fi": {
@@ -594,9 +594,9 @@
       "url" : "https://tilastot.etk.fi:443/api/[version]/[lang]/",
       "version": ["v1"],
       "lang": ["en", "fi", "sv"],
-      "calls_per_period": 100,
-      "period_in_seconds": 10,
-      "max_values_to_download" : 10000000
+      "calls_per_period": 20,
+      "period_in_seconds": 5,
+      "max_values_to_download" : 1000
     },
     
   "41.94.86.11": {
@@ -608,9 +608,9 @@
       "url" : "http://41.94.86.11/Censo2017/api/[version]/[lang]/",
       "version": ["v1"],
       "lang": ["en", "pt-PT"],
-      "calls_per_period": 100,
-      "period_in_seconds": 10,
-      "max_values_to_download" : 10000000
+      "calls_per_period": 30,
+      "period_in_seconds": 1,
+      "max_values_to_download" : 10000
     },
     
   "pc-axis.geostat.ge": {
@@ -622,9 +622,9 @@
       "url" : "http://pc-axis.geostat.ge/PXweb/api/[version]/[lang]/",
       "version": ["v1"],
       "lang": ["en", "ka"],
-      "calls_per_period": 100,
-      "period_in_seconds": 10,
-      "max_values_to_download" : 10000000
+      "calls_per_period": 30,
+      "period_in_seconds": 1,
+      "max_values_to_download" : 10000
     },
     
   "statistika.tai.ee": {
@@ -636,9 +636,9 @@
       "url" : "https://statistika.tai.ee/api/[version]/[lang]/",
       "version": ["v1"],
       "lang": ["en", "et"],
-      "calls_per_period": 100,
+      "calls_per_period": 10,
       "period_in_seconds": 10,
-      "max_values_to_download" : 10000000
+      "max_values_to_download" : 1000
     }
     
   },

--- a/tests/testthat/test-pxweb_api_catalogue.R
+++ b/tests/testthat/test-pxweb_api_catalogue.R
@@ -15,7 +15,7 @@ test_that(desc="pxweb_api_catalogue",{
   expect_silent(pxacgh <- pxweb:::pxweb_api_catalogue_from_github("master"))
   expect_output(print(pxac), regexp = "Api:")
       
-  expect_equal(pxac[[2]], pxacgh[[2]])
+  expect_equal(pxac[[1]], pxacgh[[1]])
   
 })  
 


### PR DESCRIPTION
Added new APIs to api.json. Some databases created with pxweb technology didn't have API enabled or only had test api so they were not added. Some APIs had some problems:

**Entities that did not have API available:**

National Statistical Service of the Republic of Armenia
Nordic Health and Welfare Statistics

**Entities with broken APIs:**

Örebro kommun (old pxweb API version)
EUSTAT (redirects to net-inter-eustat-45.ejgvdns, reported to their helpdesk)
INSTAT, Mali (sometimes fails, sometimes produces an error message, sometimes works, unstable internet connection?)
Icelandic Centre for Retail Studies (px.rsv.is) (no longer existing, timeouts?)

**API works fine but produces a warning:**

Sundsvall kommun

See issue #254 for a more detailed list and error messages

Also:
- bumped version
- edited CITATION to be similar with dynamically updating CITATION in sweidnumbr package